### PR TITLE
Added optional parameter filter to the query API.

### DIFF
--- a/include/tp/qt/Node.h
+++ b/include/tp/qt/Node.h
@@ -21,6 +21,7 @@
 #include <unordered_map>
 #include <cstdint>
 #include <tp/qt/QuadPoint.h>
+#include <functional>
 
 namespace TP { namespace qt {
     class Node {
@@ -36,7 +37,7 @@ namespace TP { namespace qt {
 
             void insert(const QuadPoint* point);
 
-            void query(const geom::Extent<double>& extent, std::vector<const void*>& data, std::unordered_map<long, bool>& dataManifest);
+            void query(const geom::Extent<double>& extent, std::vector<const void*>& data, std::unordered_map<long, bool>& dataManifest, std::function<bool(const geom::Extent<double>&, const QuadPoint*)>* filter);
 
         private:
             geom::Extent<double> $extent;

--- a/include/tp/qt/QuadTree.h
+++ b/include/tp/qt/QuadTree.h
@@ -24,6 +24,7 @@
 #include <tp/qt/QuadPoint.h>
 #include <tp/qt/XYPoint.h>
 #include <tp/qt/RectPoint.h>
+#include <functional>
 
 namespace TP { namespace qt {
     class QuadTree {
@@ -42,7 +43,7 @@ namespace TP { namespace qt {
             void insert(double x1, double y1, double x2, double y2, const void* data);
             void insert(const geom::Extent<double>& extent, const void* data);
             void insert(RectPoint* point, const void* data);
-            void query(const geom::Extent<double>& extent, std::vector<const void*>& outData);
+            void query(const geom::Extent<double>& extent, std::vector<const void*>& outData, std::function<bool(const geom::Extent<double>&, const QuadPoint*)>* filter = nullptr);
         private:
             Node* $root;
             std::vector<QuadPoint*> $data;

--- a/ios/quadtree/quadtree.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/quadtree/quadtree.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ios/quadtree/quadtree.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/quadtree/quadtree.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -45,7 +45,7 @@ namespace TP { namespace qt {
         return $extent;
     }
 
-    void Node::query(const Extent<double>& extent, std::vector<const void*>& dataList, std::unordered_map<long, bool>& dataManifest) {
+    void Node::query(const Extent<double>& extent, std::vector<const void*>& dataList, std::unordered_map<long, bool>& dataManifest, std::function<bool(const Extent<double>&, const QuadPoint*)>* filter) {
         // isInBounds is the first pass filter.
         // It checks to see if the requested extent is at least partially within the bounds of the quad extent.
         // The first pass filter is a very broad and inaccurate filter, it often includes many false possitives.
@@ -65,16 +65,23 @@ namespace TP { namespace qt {
                     // Most false positives are caught but long diagonal lines still have many false positives.
                     point->isInBounds(extent)
                 ) {
+                    if (
+                        // If filter is defined...
+                        filter != nullptr &&
+                        !((*filter)(extent, point))
+                    ) { // If point fails filter then continue to next point.
+                        continue;
+                    }
                     dataManifest.insert(std::pair<long, bool>(ptr, true));
                     dataList.push_back(data);
                 }
             }
 
             if ($nw != nullptr) {
-                $nw->query(extent, dataList, dataManifest);
-                $ne->query(extent, dataList, dataManifest);
-                $sw->query(extent, dataList, dataManifest);
-                $se->query(extent, dataList, dataManifest);
+                $nw->query(extent, dataList, dataManifest, filter);
+                $ne->query(extent, dataList, dataManifest, filter);
+                $sw->query(extent, dataList, dataManifest, filter);
+                $se->query(extent, dataList, dataManifest, filter);
             }
         }
     }

--- a/src/QuadTree.cpp
+++ b/src/QuadTree.cpp
@@ -54,11 +54,11 @@ namespace TP { namespace qt {
         $root->insert(point);
     }
 
-    void QuadTree::query(const geom::Extent<double>& extent, std::vector<const void*>& outData) {
+    void QuadTree::query(const geom::Extent<double>& extent, std::vector<const void*>& outData, std::function<bool(const Extent<double>&, const QuadPoint*)>* filter) {
         outData.clear();
         // This is used to keep track of data to ensure only unique data is inserted into the out array.
         // as there could be many points to one user dataset.
         std::unordered_map<long, bool> manifest;
-        $root->query(extent, outData, manifest);
+        $root->query(extent, outData, manifest, filter);
     }
 }}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -21,6 +21,10 @@ void handler(int sig) {
     exit(1);
 }
 
+bool $myfilter(const TP::geom::Extent<double>& extent, const TP::qt::QuadPoint* point) {
+    return true;
+}
+
 int main(int argc, char** argv) {
     using namespace TP::geom;
     using namespace TP::qt;
@@ -45,7 +49,8 @@ int main(int argc, char** argv) {
 
     std::vector<const void*> results;
     Extent<double> query(25.0, 25.0, 100.0, 100.0);
-    qt.query(query, results);
+    std::function<bool(const Extent<double>&, const QuadPoint*)> filter = $myfilter;
+    qt.query(query, results, &filter);
 
     if (results.size() == 0) {
         std::cout << "No Results" << std::endl;


### PR DESCRIPTION
Filter is a std::function<bool(const Extent&,const QuadPoint*)>*. It passes in the query extent and the point to test against and expects a true or false value in return. This parameter is meant to be additional filters that are ran after QuadTree's initial filters and is particularly meant to allow filters done on the data structure itself rather than basic extent comparisons.